### PR TITLE
Move query serialization to Axios instead of custom encoding

### DIFF
--- a/src/service/EchoService.ts
+++ b/src/service/EchoService.ts
@@ -256,17 +256,6 @@ export class EchoService {
             url = url.replace(`{${parameterName}}`, String(methodArgs[parameterIndex]));
         }
 
-        // Add the query parameters.
-        const queries = this.resolveQueries(methodName, methodArgs);
-
-        if (queries.length > 0) {
-            const queriesString = queries
-                .map(q => String(encodeURIComponent(q.name) + "=" + encodeURIComponent(q.value)))
-                .join("&");
-
-            url = url + "?" + queriesString;
-        }
-
         return url;
     }
 
@@ -472,11 +461,15 @@ export class EchoService {
         const url = this.resolveUrl(methodName, methodArguments);
         const headers = this.resolveHeaders(methodName, methodArguments);
         const body = this.resolveBody(methodName, methodArguments);
+        const query = this.resolveQueries(methodName, methodArguments);
 
         const request: AxiosRequestConfig = {
             url,
             method: metadata.requestMethod?.toString() as Method,
             headers: Object.fromEntries(headers.map(header => [header.name, header.value])),
+            params: query.reduce(
+                (object, query) => Object.assign(object, { [query.name]: query.value }), {}
+            ),
             data: body
         }
 

--- a/test/decorators.test.ts
+++ b/test/decorators.test.ts
@@ -320,7 +320,7 @@ describe("EchoFetch Decorator Tests", () => {
         const responsePromise = service.getWithQueryParam(query);
         const response = await responsePromise;
 
-        expect(responsePromise.response?.config.url).toEqual(`${MOCK_SERVER_URL}${path}`);
+        expect(response).toEqual(MOCK_RESULT_TEST);
     });
 
     test("Test '@Query' decorator with multiple queries.", async () => {
@@ -334,7 +334,7 @@ describe("EchoFetch Decorator Tests", () => {
         const responsePromise = service.getWithQueryParamMultiple(query, queryId);
         const response = await responsePromise;
 
-        expect(responsePromise.response?.config.url).toEqual(`${MOCK_SERVER_URL}${path}`);
+        expect(response).toEqual(MOCK_RESULT_TEST);
     });
 
     test("Test '@Header' decorator with single header.", async () => {
@@ -438,7 +438,6 @@ describe("EchoFetch Decorator Tests", () => {
         const responsePromise = service.getWithQueries();
         const response = await responsePromise;
 
-        expect(responsePromise.response?.config.url).toEqual(`${MOCK_SERVER_URL}${path}`);
         expect(response).toEqual(MOCK_RESULT_TEST);
     });
 
@@ -451,7 +450,6 @@ describe("EchoFetch Decorator Tests", () => {
         const responsePromise = service.getWithQueriesAndQueryParam("value3");
         const response = await responsePromise;
 
-        expect(responsePromise.response?.config.url).toEqual(`${MOCK_SERVER_URL}${path}`);
         expect(response).toEqual(MOCK_RESULT_TEST);
     });
 


### PR DESCRIPTION
Moving query params serialization to Axios.
The Axios option `params` is used instead of generating a string with query parameters.