### PR TITLE
Remove Vue as dependency for usage without

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,5 @@
     "dependencies": {
         "axios": "^0.19.2",
         "form-data": "^3.0.0"
-    },
-    "optionalDependencies": {
-        "vue": "^2.0.0"
     }
 }

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -7,6 +7,7 @@ const pkg = require("./package.json")
 
 export default {
     input: `src/echofetch.ts`,
+    external: ["vue"],
     output: [
         {file: pkg.main, format: "cjs", sourcemap: true},
         {file: pkg.module, format: "esm", sourcemap: true},
@@ -20,7 +21,9 @@ export default {
         typescript({useTsconfigDeclarationDir: true}),
 
         // Allow bundling cjs modules
-        commonjs(),
+        commonjs({
+            ignore: ["vue"],
+        }),
 
         // Resolve source maps to the original source
         sourceMaps(),


### PR DESCRIPTION
This removes Vue as a `peerDependency`.

I originally misunderstood the peerDependency field.
Adding Vue to that section will always install & bundle it with projects that do not require Vue.
